### PR TITLE
Corrigido erro de interpretação do AJAX

### DIFF
--- a/webapp/assets/js/cadastro.js
+++ b/webapp/assets/js/cadastro.js
@@ -11,6 +11,7 @@ function criarUsuario(evento) {
     $.ajax({
         url: "/usuarios",
         method: "POST",
+        dataType: "text",
         data: {
             nome: $('#nome').val(),
             email: $('#email').val(),

--- a/webapp/assets/js/login.js
+++ b/webapp/assets/js/login.js
@@ -6,6 +6,7 @@ function fazerLogin(evento) {
     $.ajax({
         url: "/login",
         method: "POST",
+        dataType: "text",
         data: {
             email: $('#email').val(),
             senha: $('#senha').val(),


### PR DESCRIPTION
Como o AJAX aguarda um JSON, ele tenta dar parse nele, porém, se colocar o retorno como text, o AJAX desiste de fazer o PARSE e o problema é eliminado.